### PR TITLE
좋아요 한 게시물 페이지 추가

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:lockerroom/page/legal/privacy_policy_page.dart';
 import 'package:lockerroom/page/legal/terms_of_service_page.dart';
 import 'package:lockerroom/page/login/login_page.dart';
 import 'package:lockerroom/page/login/signup_page.dart';
+import 'package:lockerroom/page/my_post/likedPosts_page.dart';
 import 'package:lockerroom/page/notice/notice_list_page.dart';
 import 'package:lockerroom/page/setting/change_password_page.dart';
 import 'package:lockerroom/page/setting/custormer_center_page.dart';
@@ -193,6 +194,7 @@ class MyApp extends StatelessWidget {
           'policy': (context) => const PrivacyPolicyPage(),
           'changePassword': (context) => const ChangePasswordPage(),
           'blockList': (context) => const BlockListPage(),
+          'likedPost': (context) => const LikedPostsPage(),
         },
       ),
     );

--- a/lib/page/my_post/likedPosts_page.dart
+++ b/lib/page/my_post/likedPosts_page.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:lockerroom/const/color.dart';
+import 'package:lockerroom/page/feed/feed_search_page.dart';
+import 'package:lockerroom/provider/feed_provider.dart';
+import 'package:provider/provider.dart';
+
+class LikedPostsPage extends StatefulWidget {
+  const LikedPostsPage({super.key});
+
+  @override
+  State<LikedPostsPage> createState() => _LikedPostsPageState();
+}
+
+class _LikedPostsPageState extends State<LikedPostsPage> {
+  late final FeedProvider _feedProvider;
+  @override
+  void initState() {
+    super.initState();
+    _feedProvider = context.read<FeedProvider>();
+    // 구독시작
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _feedProvider.subscribeLikedPosts();
+    });
+  }
+
+  @override
+  void dispose() {
+    // 페이지를 나갈때 구독취소
+    _feedProvider.cancelLikedPostsSubscription();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: BACKGROUND_COLOR,
+      appBar: AppBar(
+        backgroundColor: BACKGROUND_COLOR,
+        title: Text(
+          '좋아요한 게시물',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        scrolledUnderElevation: 0,
+      ),
+      body: Consumer<FeedProvider>(
+        builder: (context, feedProvider, child) {
+          final likedPosts = feedProvider.likedPosts;
+
+          if (likedPosts.isEmpty) {
+            return Center(child: Text('좋아요한 게시물이 없습니다.'));
+          }
+
+          return ListView.builder(
+            itemCount: likedPosts.length,
+            itemBuilder: (context, index) {
+              return PostWidget(
+                post: likedPosts[index],
+                feedProvider: feedProvider,
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/page/setting/setting_page.dart
+++ b/lib/page/setting/setting_page.dart
@@ -40,138 +40,154 @@ class SettingPage extends StatelessWidget {
         child: SingleChildScrollView(
           child: Column(
             children: [
-              GestureDetector(
-                onTap: () {},
-                child: Container(
-                  width: double.infinity,
-                  height: 200,
-                  decoration: BoxDecoration(
-                    color: GRAYSCALE_LABEL_50,
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.only(left: 20.0),
-                    child: Column(
-                      children: [
-                        TextButton(
-                          onPressed: () {
-                            Navigator.pushNamed(context, 'changeNickname');
-                          },
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Text(
-                                '닉네임 변경',
-                                style: TextStyle(
-                                  color: GRAYSCALE_LABEL_950,
-                                  fontSize: 16,
-                                ),
+              Container(
+                width: double.infinity,
+                height: 260,
+                decoration: BoxDecoration(
+                  color: GRAYSCALE_LABEL_50,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.only(left: 20.0),
+                  child: Column(
+                    children: [
+                      TextButton(
+                        onPressed: () {
+                          Navigator.pushNamed(context, 'changeNickname');
+                        },
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              '닉네임 변경',
+                              style: TextStyle(
+                                color: GRAYSCALE_LABEL_950,
+                                fontSize: 16,
                               ),
-                              IconButton(
-                                onPressed: () {
-                                  Navigator.pushNamed(
-                                    context,
-                                    'changeNickname',
-                                  );
-                                },
-                                icon: Icon(
-                                  Icons.arrow_forward_ios_rounded,
-                                  color: GRAYSCALE_LABEL_950,
-                                  size: 16,
-                                ),
+                            ),
+                            IconButton(
+                              onPressed: () {
+                                Navigator.pushNamed(context, 'changeNickname');
+                              },
+                              icon: Icon(
+                                Icons.arrow_forward_ios_rounded,
+                                color: GRAYSCALE_LABEL_950,
+                                size: 16,
                               ),
-                            ],
-                          ),
+                            ),
+                          ],
                         ),
-                        TextButton(
-                          onPressed: () {
-                            Navigator.pushNamed(context, 'changePassword');
-                          },
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Text(
-                                '비밀번호 변경',
-                                style: TextStyle(
-                                  color: GRAYSCALE_LABEL_950,
-                                  fontSize: 16,
-                                ),
+                      ),
+                      TextButton(
+                        onPressed: () {
+                          Navigator.pushNamed(context, 'changePassword');
+                        },
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              '비밀번호 변경',
+                              style: TextStyle(
+                                color: GRAYSCALE_LABEL_950,
+                                fontSize: 16,
                               ),
-                              IconButton(
-                                onPressed: () {
-                                  Navigator.pushNamed(
-                                    context,
-                                    'changePassword',
-                                  );
-                                },
-                                icon: Icon(
-                                  Icons.arrow_forward_ios_rounded,
-                                  color: GRAYSCALE_LABEL_950,
-                                  size: 16,
-                                ),
+                            ),
+                            IconButton(
+                              onPressed: () {
+                                Navigator.pushNamed(context, 'changePassword');
+                              },
+                              icon: Icon(
+                                Icons.arrow_forward_ios_rounded,
+                                color: GRAYSCALE_LABEL_950,
+                                size: 16,
                               ),
-                            ],
-                          ),
+                            ),
+                          ],
                         ),
-                        TextButton(
-                          onPressed: () async {
-                            final changed = await Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) =>
-                                    TeamSelectPage(isChanging: true),
-                              ),
-                            );
+                      ),
+                      TextButton(
+                        onPressed: () async {
+                          final changed = await Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) =>
+                                  TeamSelectPage(isChanging: true),
+                            ),
+                          );
 
-                            toastification.show(
-                              context: context,
-                              type: ToastificationType.success,
-                              alignment: Alignment.bottomCenter,
-                              autoCloseDuration: const Duration(seconds: 2),
-                              title: Text('팀이 변경되었습니다: $changed'),
-                            );
-                          },
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Text(
-                                '응원팀 변경',
-                                style: TextStyle(
-                                  color: GRAYSCALE_LABEL_950,
-                                  fontSize: 16,
-                                ),
+                          toastification.show(
+                            context: context,
+                            type: ToastificationType.success,
+                            alignment: Alignment.bottomCenter,
+                            autoCloseDuration: const Duration(seconds: 2),
+                            title: Text('팀이 변경되었습니다: $changed'),
+                          );
+                        },
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              '응원팀 변경',
+                              style: TextStyle(
+                                color: GRAYSCALE_LABEL_950,
+                                fontSize: 16,
                               ),
-                              IconButton(
-                                onPressed: () async {
-                                  final changed = await Navigator.push(
-                                    context,
-                                    MaterialPageRoute(
-                                      builder: (context) =>
-                                          TeamSelectPage(isChanging: true),
-                                    ),
-                                  );
+                            ),
+                            IconButton(
+                              onPressed: () async {
+                                final changed = await Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (context) =>
+                                        TeamSelectPage(isChanging: true),
+                                  ),
+                                );
 
-                                  toastification.show(
-                                    context: context,
-                                    type: ToastificationType.success,
-                                    alignment: Alignment.bottomCenter,
-                                    autoCloseDuration: const Duration(
-                                      seconds: 2,
-                                    ),
-                                    title: Text('팀이 변경되었습니다: $changed'),
-                                  );
-                                },
-                                icon: Icon(
-                                  Icons.arrow_forward_ios_rounded,
-                                  color: GRAYSCALE_LABEL_950,
-                                  size: 16,
-                                ),
+                                toastification.show(
+                                  context: context,
+                                  type: ToastificationType.success,
+                                  alignment: Alignment.bottomCenter,
+                                  autoCloseDuration: const Duration(seconds: 2),
+                                  title: Text('팀이 변경되었습니다: $changed'),
+                                );
+                              },
+                              icon: Icon(
+                                Icons.arrow_forward_ios_rounded,
+                                color: GRAYSCALE_LABEL_950,
+                                size: 16,
                               ),
-                            ],
-                          ),
+                            ),
+                          ],
                         ),
-                      ],
-                    ),
+                      ),
+                      TextButton(
+                        onPressed: () {
+                          Navigator.pushNamed(context, 'likedPost');
+                        },
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              '좋아요',
+                              style: TextStyle(
+                                color: GRAYSCALE_LABEL_950,
+                                fontSize: 16,
+                              ),
+                            ),
+                            IconButton(
+                              onPressed: () {
+                                Navigator.pushNamed(context, 'likedPost');
+                              },
+                              icon: Icon(
+                                Icons.arrow_forward_ios_rounded,
+                                color: GRAYSCALE_LABEL_950,
+                                size: 16,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ),


### PR DESCRIPTION
### 구현 내용
- 사용자가 좋아요를 누른 게시물만 필터링하여 보여주는 페이지 추가
- Firestore 실시간 구독을 통한 자동 업데이트 기능

### 변경사항
- `FeedProvider`에 좋아요 게시물 구독 메서드 추가
  - `subscribeLikedPosts()`: 좋아요한 게시물 실시간 구독
  - `cancelLikedPostsSubscription()`: 구독 취소 및 리소스 관리
- `LikedPostsPage` 생성: 좋아요한 게시물 목록 UI